### PR TITLE
[DPE-6078] rename OCI image to `valkey`

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,4 +24,4 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: valkey-rock
-          path: charmed-valkey_*_amd64.rock
+          path: valkey_*_amd64.rock

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,8 +48,8 @@ jobs:
           rock_image_version=$(yq '(.version)' rockcraft.yaml)
           base=$(yq '(.base|split("@"))[1]' rockcraft.yaml)
           tag=${version}-${base}-${{ env.RELEASE }}
-          echo "Publishing charmed-valkey:${tag}"
+          echo "Publishing valkey:${tag}"
           sudo skopeo --insecure-policy copy \
-            oci-archive:charmed-valkey_${rock_image_version}_amd64.rock \
-            docker-daemon:ghcr.io/canonical/charmed-valkey:${tag}
-          docker push ghcr.io/canonical/charmed-valkey:${tag}
+            oci-archive:valkey_${rock_image_version}_amd64.rock \
+            docker-daemon:ghcr.io/canonical/valkey:${tag}
+          docker push ghcr.io/canonical/valkey:${tag}

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ cd charmed-valkey-rock
 sudo snap install rockcraft --edge --classic
 sudo snap install docker
 sudo snap install lxd
-sudo snap install skopeo --edge --devmode
+sudo apt-get -y update && sudo apt-get -y install skopeo
 ```
 ### Configuring Prerequisites
 ```bash
@@ -29,8 +29,8 @@ sudo lxd init --auto
 ### Packing and Running the rock
 ```bash
 rockcraft pack
-sudo skopeo --insecure-policy copy oci-archive:charmed-valkey*.rock docker-daemon:<username>/charmed-valkey:<tag>
-docker run --rm -it <username>/charmed-valkey:<tag>
+sudo skopeo --insecure-policy copy oci-archive:valkey*.rock docker-daemon:valkey:<tag>
+docker run --rm -it valkey:<tag>
 ```
 
 ## License:

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -1,10 +1,10 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE-rock file for licensing details.
 ---
-name: charmed-valkey  # the name of your ROCK
+name: valkey  # the name of your ROCK
 base: ubuntu@22.04  # the base environment for this ROCK
 version: '7.2.5'  # just for humans. Semantic versioning is recommended
-summary: Charmed Valkey ROCK OCI  # 79 char long summary
+summary: Valkey ROCK OCI  # 79 char long summary
 description: |
   This is an OCI image that bundles Valkey together with the metrics exporter
   in order to be used in Charmed Operators, providing automated operations 


### PR DESCRIPTION
In order to publish the image to Dockerhub, we want to fix the naming of the OCI image and rename it from `charmed-valkey` to `valkey`.