### PR TITLE
update valkey to 7.2.7

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -55,3 +55,11 @@ parts:
     source-branch: "v1.60.0"
     build-snaps:
       - go/1.21/stable
+  deb-security-manifest:
+    plugin: nil
+    after:
+      - redis_exporter
+    override-prime: |
+      set -x
+      mkdir -p $CRAFT_PRIME/usr/share/rocks/
+      (echo "# os-release" && cat /etc/os-release && echo "# dpkg-query" && dpkg-query --admindir=$CRAFT_PRIME/var/lib/dpkg/ -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W) > $CRAFT_PRIME/usr/share/rocks/dpkg.query

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -2,8 +2,8 @@
 # See LICENSE-rock file for licensing details.
 ---
 name: valkey  # the name of your ROCK
-base: ubuntu@22.04  # the base environment for this ROCK
-version: '7.2.5'  # just for humans. Semantic versioning is recommended
+base: ubuntu@24.04  # the base environment for this ROCK
+version: '7.2.7'  # just for humans. Semantic versioning is recommended
 summary: Valkey ROCK OCI  # 79 char long summary
 description: |
   This is an OCI image that bundles Valkey together with the metrics exporter

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -62,4 +62,4 @@ parts:
     override-prime: |
       set -x
       mkdir -p $CRAFT_PRIME/usr/share/rocks/
-      (echo "# os-release" && cat /etc/os-release && echo "# dpkg-query" && dpkg-query --admindir=$CRAFT_PRIME/var/lib/dpkg/ -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W) > $CRAFT_PRIME/usr/share/rocks/dpkg.query
+      (echo "# os-release" && cat /etc/os-release && echo "# dpkg-query" && dpkg-query -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W) > $CRAFT_PRIME/usr/share/rocks/dpkg.query


### PR DESCRIPTION
This PR updates the valkey rock image to:
- valkey 7.2.7
- Ubuntu 24.04

It also adds a security manifest for the installed packages in /usr/share/rocks/dpkg.query