### PR TITLE
[DPE-6078] update metrics exporter

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -54,7 +54,7 @@ parts:
     source-type: git
     source-branch: "v1.67.0"
     build-snaps:
-      - go/1.21/stable
+      - go/1.23/stable
   deb-security-manifest:
     plugin: nil
     after:

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -52,7 +52,7 @@ parts:
       - valkey-user
     source: https://github.com/canonical/redis_exporter.git
     source-type: git
-    source-branch: "v1.60.0"
+    source-branch: "v1.67.0"
     build-snaps:
       - go/1.21/stable
   deb-security-manifest:


### PR DESCRIPTION
Update redis_exporter to v1.67.0 from upstream-fork because of vulnerability in go stdlib 1.21 (see: https://github.com/canonical/oci-factory/pull/306#pullrequestreview-2549403323).