### PR TITLE
[DPE-7550] update metrics exporter

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -52,7 +52,7 @@ parts:
       - valkey-user
     source: https://github.com/canonical/redis_exporter.git
     source-type: git
-    source-branch: "v1.67.0"
+    source-branch: "v1.74.0"
     build-snaps:
       - go/1.23/stable
   deb-security-manifest:


### PR DESCRIPTION
The following vulnerability was identified:

[CVE-2025-22874](https://github.com/advisories/GHSA-6f52-wpx2-hvf2)

This PR fixes the issue by using v1.74.0 of redis_exporter.