### PR TITLE
[DPE-9314] add openssl package

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -37,6 +37,8 @@ parts:
     plugin: nil
     stage-snaps:
       - charmed-valkey/9/edge
+    stage-packages:
+      - openssl
   valkey-user:
     plugin: nil
     after:


### PR DESCRIPTION
In order to perform TLS related operations on the Valkey rock image, it would be beneficial to install the `openssl` package.