### PR TITLE
chore: pin trivy action to 0.35.0

### DIFF
--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -30,7 +30,7 @@ jobs:
             docker-daemon:trivy/valkey:test
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.35.0
         with:
           image-ref: 'trivy/valkey:test'
           format: 'sarif'


### PR DESCRIPTION
https://www.stepsecurity.io/blog/trivy-compromised-a-second-time---malicious-v0-69-4-release