### PR TITLE
patch: Use dp workflows to build and release rock

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,22 +6,5 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-      - name: Setup LXD
-        uses: canonical/setup-lxd@main
-      - name: Install dependencies
-        run: |
-          sudo snap install yq
-          sudo snap install rockcraft --classic
-      - name: Build ROCK
-        run: |
-          rockcraft pack
-      - name: Upload locally built ROCK artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: valkey-rock
-          path: valkey_*_amd64.rock
+    name: Build rock
+    uses: canonical/data-platform-workflows/.github/workflows/build_rock.yaml@v42.0.1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,45 +11,13 @@ on:
 jobs:
   build:
     uses: ./.github/workflows/build.yaml
-  publish:
-    needs: build
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
+  release:
+    name: Release rock
+    needs:
+      - build
+    uses: canonical/data-platform-workflows/.github/workflows/release_rock.yaml@v42.0.1
+    with:
+      artifact-prefix: ${{ needs.build.outputs.artifact-prefix }}
     permissions:
-      packages: write
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-      - name: Setup Docker
-        run: |
-          sudo snap install docker
-          sudo addgroup --system docker; sudo adduser $USER docker
-          newgrp docker
-          sudo snap disable docker; sudo snap enable docker
-      - name: Install rockcraft.skopeo
-        run: |
-          sudo snap install rockcraft --classic
-      - name: Install yq
-        run: |
-          sudo snap install yq
-      - uses: actions/download-artifact@v4
-        with:
-          name: valkey-rock
-          path: .
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ secrets.GHCR_USER }}
-          password: ${{ secrets.GHCR_TOKEN }}
-      - name: Import and push to GHCR
-        run: |
-          version=$(yq '(.version|split("-"))[0]' rockcraft.yaml)
-          rock_image_version=$(yq '(.version)' rockcraft.yaml)
-          base=$(yq '(.base|split("@"))[1]' rockcraft.yaml)
-          tag=${version}-${base}-${{ env.RELEASE }}
-          echo "Publishing valkey:${tag}"
-          sudo rockcraft.skopeo --insecure-policy copy \
-            oci-archive:valkey_${rock_image_version}_amd64.rock \
-            docker-daemon:ghcr.io/canonical/valkey:${tag}
-          docker push ghcr.io/canonical/valkey:${tag}
+      packages: write # Needed to publish to GitHub Container Registry
+      contents: write # Needed to create git tags


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration to use standardized, reusable workflows from the `canonical/data-platform-workflows` repository for both building and releasing the rock artifact. This change simplifies the workflow files by removing custom steps and delegating the build and release logic to maintained, versioned workflows.

**Workflow modernization and simplification:**

* [`.github/workflows/build.yaml`](diffhunk://#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1L9-R10): Replaces the custom build job with a single step that uses the `build_rock.yaml` workflow from `canonical/data-platform-workflows@v42.0.1`, removing all individual build steps.
* [`.github/workflows/release.yaml`](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL14-R23): Removes the custom publish job and replaces it with a `release` job that uses the `release_rock.yaml` workflow from `canonical/data-platform-workflows@v42.0.1`, passing the build artifact prefix as an input and updating permissions accordingly.