### PR TITLE
patch: Add license header and rely on build dp workflow in release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,16 +1,22 @@
-name: Publish to GHCR
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+name: Release to GHCR
 
-env:
-  RELEASE: edge
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 on:
   push:
     branches:
       - 9-26.04
+  workflow_dispatch:
 
 jobs:
   build:
-    uses: ./.github/workflows/build.yaml
+    name: Build rock
+    uses: canonical/data-platform-workflows/.github/workflows/build_rock.yaml@v42.0.1
+
   release:
     name: Release rock
     needs:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,6 +1,6 @@
 # Copyright 2026 Canonical Ltd.
 # See LICENSE file for licensing details.
-name: Release to GHCR
+name: Publish to GHCR
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for releasing to GHCR, focusing on improving maintainability and workflow management. The main changes include switching to a reusable workflow from an external repository, adding concurrency controls, and updating workflow metadata.

**Workflow improvements:**

* The workflow now uses the reusable `build_rock.yaml` from the `canonical/data-platform-workflows` repository instead of a local `build.yaml`, ensuring consistency and easier maintenance.
* Concurrency controls have been added to prevent overlapping workflow runs, using a group based on the workflow name and git reference.
* The workflow can now be triggered manually with `workflow_dispatch`, in addition to pushes to the `9-26.04` branch.

**Metadata and naming updates:**

* The workflow name has been changed to "Release to GHCR", and copyright/license headers were added for clarity and compliance.