### PR TITLE
fix: Rename rock to charmed-valkey

### DIFF
--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -20,25 +20,25 @@ jobs:
           sudo snap install rockcraft --classic
       - uses: actions/download-artifact@v4
         with:
-          name: valkey-rock
+          name: charmed-valkey-rock
           path: .
       - name: Import locally
         run: |
           rock_image_version=$(yq '(.version)' rockcraft.yaml)
           sudo rockcraft.skopeo --insecure-policy copy \
-            oci-archive:valkey_${rock_image_version}_amd64.rock \
-            docker-daemon:trivy/valkey:test
+            oci-archive:charmed-valkey_${rock_image_version}_amd64.rock \
+            docker-daemon:trivy/charmed-valkey:test
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@0.35.0
         with:
-          image-ref: 'trivy/valkey:test'
-          format: 'sarif'
-          output: 'trivy-results.sarif'
-          severity: 'MEDIUM,HIGH,CRITICAL'
+          image-ref: "trivy/charmed-valkey:test"
+          format: "sarif"
+          output: "trivy-results.sarif"
+          severity: "MEDIUM,HIGH,CRITICAL"
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v2
         if: always()
         with:
-          sarif_file: 'trivy-results.sarif'
+          sarif_file: "trivy-results.sarif"

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ sudo lxd init --auto
 ### Packing and Running the rock
 ```bash
 rockcraft pack
-sudo skopeo --insecure-policy copy oci-archive:valkey*.rock docker-daemon:valkey:<tag>
-docker run --rm -it valkey:<tag>
+sudo skopeo --insecure-policy copy oci-archive:charmed-valkey*.rock docker-daemon:charmed-valkey:<tag>
+docker run --rm -it charmed-valkey:<tag>
 ```
 
 ## License:

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -1,7 +1,7 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE-rock file for licensing details.
 ---
-name: valkey
+name: charmed-valkey
 base: ubuntu@26.04
 build-base: devel # to be removed once 26.04 is released to stable
 version: "9.0.1"


### PR DESCRIPTION
This pull request updates the project to use the new name `charmed-valkey` instead of `valkey` throughout the configuration, workflow, and documentation files. This ensures consistency across the build process, CI workflows, and user instructions.

**Project renaming and consistency:**

* Renamed the project in `rockcraft.yaml` from `valkey` to `charmed-valkey` to reflect the new naming convention.
* Updated artifact and image references in the GitHub Actions workflow (`.github/workflows/trivy.yaml`) to use `charmed-valkey` instead of `valkey`, ensuring CI/CD processes align with the new name.
* Modified documentation in `README.md` to update CLI commands and Docker image names from `valkey` to `charmed-valkey`, providing accurate instructions for users.