### PR TITLE
update Valkey to 7.2.12

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -3,7 +3,7 @@
 ---
 name: valkey  # the name of your ROCK
 base: ubuntu@24.04  # the base environment for this ROCK
-version: '7.2.11'  # just for humans. Semantic versioning is recommended
+version: '7.2.12'  # just for humans. Semantic versioning is recommended
 summary: Valkey ROCK OCI  # 79 char long summary
 description: |
   This is an OCI image that bundles Valkey together with the metrics exporter


### PR DESCRIPTION
This PR addresses security issues for the Valkey 7 rock image, see for example [this one](https://github.com/canonical/charmed-valkey-rock/issues/41). It updates the Valkey version to 7.2.12 and also updates the Go version used for the metric exporter.