### PR TITLE
chore: use go 1.25 for metric exporter

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -54,7 +54,7 @@ parts:
     source-type: git
     source-branch: "v1.74.0"
     build-snaps:
-      - go/1.24/stable
+      - go/1.25/stable
   deb-security-manifest:
     plugin: nil
     after:


### PR DESCRIPTION
As go 1.24 is EOL since 02/26, the go version for the metric exporter needs to be updated.